### PR TITLE
Updated di-auto.sh to work with scripts that use $APPNAME

### DIFF
--- a/di-auto.sh
+++ b/di-auto.sh
@@ -38,7 +38,18 @@ do
       # This FAILS for Evernote and hazel
 
       LOC=`grep -m1 INSTALL_TO $i`
-    
+
+      # Some of the new scripts have started using $APPNAME breaking the INSTALL_TO convention
+      # Now we have to check for $APPNAME, and pull it out if it exists
+      if [[ "$LOC" =~ "APPNAME" ]]
+      then
+        APPNAME=`grep -m1 APPNAME $i`
+        APPNAME=$(echo "$APPNAME" | cut -d'=' -f2 | cut -c 2- | rev | cut -c 2- | rev)
+        # Split $LOC, removing '$APPNAME' and rebuild it with $APPNAME
+        PREFIX=${${LOC}%'$APPNAME'*}
+        SUFFIX=${${LOC}#*APPNAME}
+        LOC=$PREFIX$APPNAME$SUFFIX
+      fi
       # There must be a better way to do this.  We split on the = and then use rev to flip the string
       LOCATION=$(echo "$LOC" | cut -d'=' -f2 | cut -c 2- | rev | cut -c 2- | rev)
 


### PR DESCRIPTION
Some of the new scripts, instead of using something like:

`INSTALL_TO='/Applications/Flux.app'`

now use:

`APPNAME="BetterTouchTool"`
`...`
`INSTALL_TO="/Applications/$APPNAME.app"`

Updated di-auto.sh so it now checks for $APPNAME in the INSTALL_TO line, and replaces it if necessary.
